### PR TITLE
Add customizable format for `list`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+columnize
 suds
 dnspython


### PR DESCRIPTION
The default is output in columns, similar to `ls`, which fits a lot of info in a small space. Other options include `1perline`, `json`, and `json_pretty`.

```
❯ f5-cli pool list
/Common/qa_anonweb_pool            /Common/mt2-authsvc_pool          /Common/mt4-emailsvc_pool
/Common/outbound_mta_pool          /Common/mt2-benchmarksvc_pool     /Common/mt4-highfiver_pool
/Common/qa_profilesvc_pool         /Common/mt2-billapi_pool          /Common/mt4-jobsvc_pool 
```
