### PR TITLE
Add debug flag

### DIFF
--- a/f5_cli/connection.py
+++ b/f5_cli/connection.py
@@ -3,11 +3,12 @@ import bigsuds
 
 class Connection(object):
 
-    def __init__(self, host, user, password, partition):
+    def __init__(self, host, user, password, partition, debug=False):
         self.host = host
         self.user = user
         self.password = password
         self.partition = partition
+        self.debug = debug
 
     def connect(self):
         """Create a connection to the device."""
@@ -15,7 +16,8 @@ class Connection(object):
             bigip = bigsuds.BIGIP(
                 hostname=self.host,
                 username=self.user,
-                password=self.password)
+                password=self.password,
+                debug=self.debug)
             try:
                 bclient = bigip.with_session_id()
                 bclient.System.Session.set_transaction_timeout(60)

--- a/f5_cli/f5_cli.py
+++ b/f5_cli/f5_cli.py
@@ -27,7 +27,7 @@ objects = [
 actions = ["list", "create", "delete"]
 
 
-def get_f5_connection(host, username, password, partition):
+def get_f5_connection(host, username, password, partition, debug=False):
     """
     create a connection object to an f5 and return it
 
@@ -37,7 +37,8 @@ def get_f5_connection(host, username, password, partition):
     @param partition - partition to work with
     """
     try:
-        connection = Connection(host, username, password, partition).connect()
+        connection = Connection(
+            host, username, password, partition, debug=debug).connect()
     except Exception as e:
         print("ERROR: {}".format(e))
         return False
@@ -107,7 +108,9 @@ def main():
         prompt = 'Password for {user}@{host}: '.format(user=user, host=host)
         password = getpass.getpass(prompt)
 
-    connection = get_f5_connection(host, user, password, args.partition)
+    connection = get_f5_connection(
+        host, user, password, args.partition,
+        debug=True)
     if not connection:
         raise Exception("Unable to get F5 connection")
 


### PR DESCRIPTION
Add support for the `debug` flag in bigsuds so that you can see what all of the various methods are:

```
(Pdb) pool = connection.LocalLB.Pool
(Pdb) dir(pool)
['__class__', '__delattr__', '__dict__', '__doc__', '__format__', '__getattr__', '__getattribute__', '__hash__', '__init__', '__module__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_arg_factory', '_client', '_result_factory', '_usage', '_wsdl_name', 'add_member', 'add_member_metadata', 'add_member_profile', 'add_member_v2', 'add_metadata', 'add_profile', 'create', 'create_v2', 'delete_all_pools', 'delete_persistence_record', 'delete_pool', 'get_action_on_service_down', 'get_active_member_count', 'get_aggregate_dynamic_ratio', 'get_all_member_statistics', 'get_all_statistics', 'get_allow_nat_state', 'get_allow_snat_state', 'get_client_ip_tos', 'get_client_link_qos', 'get_description', 'get_gateway_failsafe_device', 'get_gateway_failsafe_unit_id', 'get_ignore_persisted_weight_state', 'get_lb_method', 'get_list', 'get_member', 'get_member_address', 'get_member_connection_limit', 'get_member_description', 'get_member_dynamic_ratio', 'get_member_inherit_profile_state', 'get_member_metadata', 'get_member_metadata_description', 'get_member_metadata_persistence', 'get_member_metadata_value', 'get_member_monitor_instance', 'get_member_monitor_logging_state', 'get_member_monitor_rule', 'get_member_monitor_status', 'get_member_object_status', 'get_member_priority', 'get_member_profile', 'get_member_rate_limit', 'get_member_ratio', 'get_member_session_status', 'get_member_statistics', 'get_member_v2', 'get_metadata', 'get_metadata_description', 'get_metadata_persistence', 'get_metadata_value', 'get_minimum_active_member', 'get_minimum_up_member', 'get_minimum_up_member_action', 'get_minimum_up_member_enabled_state', 'get_monitor_association', 'get_monitor_instance', 'get_object_status', 'get_persistence_record', 'get_profile', 'get_queue_depth_limit', 'get_queue_on_connection_limit_state', 'get_queue_time_limit', 'get_reselect_tries', 'get_server_ip_tos', 'get_server_link_qos', 'get_simple_timeout', 'get_slow_ramp_time', 'get_statistics', 'get_version', 'remove_all_member_metadata', 'remove_all_member_profiles', 'remove_all_metadata', 'remove_all_profiles', 'remove_member', 'remove_member_metadata', 'remove_member_profile', 'remove_member_v2', 'remove_metadata', 'remove_monitor_association', 'remove_profile', 'reset_member_statistics', 'reset_statistics', 'set_action_on_service_down', 'set_allow_nat_state', 'set_allow_snat_state', 'set_client_ip_tos', 'set_client_link_qos', 'set_description', 'set_gateway_failsafe_device', 'set_gateway_failsafe_unit_id', 'set_ignore_persisted_weight_state', 'set_lb_method', 'set_member_connection_limit', 'set_member_description', 'set_member_dynamic_ratio', 'set_member_inherit_profile_state', 'set_member_metadata_description', 'set_member_metadata_persistence', 'set_member_metadata_value', 'set_member_monitor_logging_state', 'set_member_monitor_rule', 'set_member_monitor_state', 'set_member_priority', 'set_member_rate_limit', 'set_member_ratio', 'set_member_session_enabled_state', 'set_metadata_description', 'set_metadata_persistence', 'set_metadata_value', 'set_minimum_active_member', 'set_minimum_up_member', 'set_minimum_up_member_action', 'set_minimum_up_member_enabled_state', 'set_monitor_association', 'set_queue_depth_limit', 'set_queue_on_connection_limit_state', 'set_queue_time_limit', 'set_reselect_tries', 'set_server_ip_tos', 'set_server_link_qos', 'set_simple_timeout', 'set_slow_ramp_time']
```
