### PR TITLE
Fixes a problem that crept in there somehow

### DIFF
--- a/f5_cli/f5_cli.py
+++ b/f5_cli/f5_cli.py
@@ -170,6 +170,7 @@ def main():
                 if item.startswith(args.strip_prefix):
                     item = item[len(args.strip_prefix):]
                 obj_list.append(item)
+            formatter = ListFormatters.get(args.formatter)
             print(formatter(obj_list))
         elif args.action == "create":
             result = object_connection.create(parser)


### PR DESCRIPTION
Without this, I get this error:

    $ f5-cli pool list
    Traceback (most recent call last):
      File "/Users/marca/python/virtualenvs/f5-cli/bin/f5-cli", line 10, in <module>
        sys.exit(main())
      File "/Users/marca/dev/git-repos/f5-cli/f5_cli/f5_cli.py", line 173, in main
        print(formatter(obj_list))
    NameError: global name 'formatter' is not defined