### PR TITLE
Less exception catching

### DIFF
--- a/f5_cli/connection.py
+++ b/f5_cli/connection.py
@@ -12,18 +12,12 @@ class Connection(object):
 
     def connect(self):
         """Create a connection to the device."""
-        try:
-            bigip = bigsuds.BIGIP(
-                hostname=self.host,
-                username=self.user,
-                password=self.password,
-                debug=self.debug)
-            try:
-                bclient = bigip.with_session_id()
-                bclient.System.Session.set_transaction_timeout(60)
-                bclient.System.Session.set_active_folder("/" + self.partition)
-                return bclient
-            except bigsuds.OperationFailed as e:
-                print(e)
-        except bigsuds.ConnectionError as e:
-            raise Exception("Authentication failed")
+        bigip = bigsuds.BIGIP(
+            hostname=self.host,
+            username=self.user,
+            password=self.password,
+            debug=self.debug)
+        bclient = bigip.with_session_id()
+        bclient.System.Session.set_transaction_timeout(60)
+        bclient.System.Session.set_active_folder("/" + self.partition)
+        return bclient

--- a/f5_cli/f5_cli.py
+++ b/f5_cli/f5_cli.py
@@ -39,13 +39,8 @@ def get_f5_connection(host, username, password, partition, debug=False):
     @param password - the password to connect with
     @param partition - partition to work with
     """
-    try:
-        connection = Connection(
-            host, username, password, partition, debug=debug).connect()
-    except Exception as e:
-        print("ERROR: {}".format(e))
-        return False
-
+    connection = Connection(
+        host, username, password, partition, debug=debug).connect()
     return connection
 
 


### PR DESCRIPTION
I'm finding the catching of exceptions to be hiding useful info when troubleshooting. I like seeing the traceback.

```
$ f5-cli pool list
Traceback (most recent call last):
  File "/Users/marca/python/virtualenvs/f5-cli/bin/f5-cli", line 10, in <module>
    sys.exit(main())
  File "/Users/marca/dev/git-repos/f5-cli/f5_cli/f5_cli.py", line 150, in main
    debug=True)
  File "/Users/marca/dev/git-repos/f5-cli/f5_cli/f5_cli.py", line 43, in get_f5_connection
    host, username, password, partition, debug=debug).connect()
  File "/Users/marca/dev/git-repos/f5-cli/f5_cli/connection.py", line 19, in connect
    debug=self.debug)
  File "/Users/marca/dev/git-repos/f5-cli/f5_cli/bigsuds.py", line 112, in __init__
    self._instantiate_namespaces()
  File "/Users/marca/dev/git-repos/f5-cli/f5_cli/bigsuds.py", line 170, in _instantiate_namespaces
    self._password)
  File "/Users/marca/dev/git-repos/f5-cli/f5_cli/bigsuds.py", line 275, in get_wsdls
    raise ConnectionError(str(e))
f5_cli.bigsuds.ConnectionError: <urlopen error [Errno 8] nodename nor servname provided, or not known>
```